### PR TITLE
Add dependency to libnotify4 for publishing a debian package

### DIFF
--- a/Photino.PublishPhotino/PublishPhotino/PublishPhotino.csproj
+++ b/Photino.PublishPhotino/PublishPhotino/PublishPhotino.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Photino.NET" Version="3.1.18" />
+    <PackageReference Include="Photino.NET" Version="4.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Photino.PublishPhotino/PublishPhotino/README.md
+++ b/Photino.PublishPhotino/PublishPhotino/README.md
@@ -329,7 +329,7 @@ Maintainer: your name <yourname@example.com>
 Package: PublishPhotino
 Version: 1.0.0
 Architecture: amd64
-Depends: libc6 (>= 2.31), gir1.2-gtk-3.0 (>= 3.24), libwebkit2gtk-4.1-0 (>= 2.42)
+Depends: libc6 (>= 2.31), gir1.2-gtk-3.0 (>= 3.24), libwebkit2gtk-4.1-0 (>= 2.42), libnotify4 (>= 0.8)
 Description: PublishPhotino
   A simple Photino application.
 ```

--- a/Photino.PublishPhotino/publish/templates/linux/deb/DEBIAN/control
+++ b/Photino.PublishPhotino/publish/templates/linux/deb/DEBIAN/control
@@ -5,6 +5,6 @@ Maintainer: APP_MAINTAINER
 Package: APP_NAME_LCD
 Version: APP_VERSION
 Architecture: APP_ARCH
-Depends: libc6 (>= 2.31), gir1.2-gtk-3.0 (>= 3.24), libwebkit2gtk-4.1-0 (>= 2.42)
+Depends: libc6 (>= 2.31), gir1.2-gtk-3.0 (>= 3.24), libwebkit2gtk-4.1-0 (>= 2.42), libnotify4 (>= 0.8)
 Description: APP_DESC_SHORT
   APP_DESC_LONG


### PR DESCRIPTION
Photino.Native depends on package libnotify(4)
see [README.md](https://github.com/tryphotino/photino.Native/blob/master/README.md):
```
gcc -std=c++11 -shared -DOS_LINUX Exports.cpp Photino.Linux.cpp -o x64/$(buildConfiguration)/Photino.Native.so 'pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0 libnotify' -fPIC
```
at least I had to install libnotify4 on my fresh debian V12.